### PR TITLE
Revive TIL (Today I Learned) blog section

### DIFF
--- a/.claude/commands/til.md
+++ b/.claude/commands/til.md
@@ -1,0 +1,74 @@
+---
+description: Create a new Today I Learned (TIL) blog post from notes
+---
+
+You are helping the user create a new TIL (Today I Learned) post for their Hugo blog.
+
+## Instructions
+
+1. **Get the content**: The user will provide notes or content for the TIL post after the `/til` command. If no content is provided, ask the user for their notes.
+
+2. **Extract title**: From the user's notes:
+   - If the notes start with a clear title (like "# Title" or a short first line), use that as the title
+   - Otherwise, generate a concise, descriptive title (5-10 words max) that captures the main learning
+   - The title should be in sentence case (not Title Case)
+
+3. **Generate slug**: Create a URL-friendly slug from the title:
+   - Convert to lowercase
+   - Replace spaces with hyphens
+   - Remove special characters
+   - Keep it short and descriptive
+
+4. **Format the content**:
+   - Remove any title line from the content if you extracted it as the title
+   - Clean up the formatting to be proper markdown
+   - Ensure code blocks are properly formatted
+   - Keep it concise (TIL posts should be brief)
+
+5. **Create the file**: Generate a new markdown file in `content/post/til/` with:
+   - Filename format: `YYYY-MM-DD-slug.md` (using today's date)
+   - Proper frontmatter (see template below)
+   - The formatted content
+
+## TIL Post Frontmatter Template
+
+```yaml
+---
+title: [Generated or extracted title]
+date: [Today's date in YYYY-MM-DDTHH:MM:SS.000Z format]
+categories:
+    - Today I Learned
+image: /images/til.png
+tags:
+    - [Relevant tags based on content]
+---
+```
+
+## Example
+
+User input: "You can use `git check-ignore -v path/to/file` to debug which .gitignore rule is excluding a file"
+
+Generated file: `content/post/til/2025-11-10-git-check-ignore-debugging.md`
+
+```yaml
+---
+title: Debugging .gitignore with git check-ignore
+date: 2025-11-10T00:00:00.000Z
+categories:
+    - Today I Learned
+image: /images/til.png
+tags:
+    - git
+---
+
+You can use `git check-ignore -v path/to/file` to debug which .gitignore rule is excluding a file from version control.
+```
+
+## Important Notes
+
+- TIL posts should be concise (1-3 paragraphs typically)
+- Always use the `/images/til.png` image
+- Always include the "Today I Learned" category
+- Add relevant tags to help with organization
+- Use today's date automatically
+- After creating the file, show the user the file path and suggest they can edit it if needed

--- a/content/til.md
+++ b/content/til.md
@@ -1,0 +1,12 @@
+---
+title: "Today I Learned"
+description: "A collection of quick tips, tricks, and things I've learned"
+layout: til
+menu:
+    main:
+        weight: 2
+        params:
+            icon: lightbulb
+---
+
+This is a collection of short posts about things I've learned - quick tips, tricks, and insights that don't warrant a full blog post.

--- a/content/til.md
+++ b/content/til.md
@@ -5,8 +5,6 @@ layout: til
 menu:
     main:
         weight: 2
-        params:
-            icon: lightbulb
 ---
 
 This is a collection of short posts about things I've learned - quick tips, tricks, and insights that don't warrant a full blog post.

--- a/layouts/_default/til.html
+++ b/layouts/_default/til.html
@@ -1,22 +1,21 @@
 {{ define "main" }}
-    <article class="main-article">
-        <header class="article-header">
-            <h1 class="article-title">{{ .Title }}</h1>
-            {{ if .Params.description }}
-            <p class="article-subtitle">{{ .Params.description }}</p>
-            {{ end }}
-        </header>
-
-        <section class="article-content">
-            {{ .Content }}
-        </section>
-    </article>
-
     {{ $tilPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") }}
     {{ $tilPosts := $tilPosts.ByDate.Reverse }}
 
-    <section class="article-list" style="margin-top: 2rem;">
-        <h2>All TIL Posts ({{ len $tilPosts }})</h2>
+    <header class="page-header">
+        <h1>{{ .Title }}</h1>
+        {{ with .Params.description }}
+            <div class="page-description">{{ . }}</div>
+        {{ end }}
+    </header>
+
+    {{ with .Content }}
+        <article style="margin-bottom: var(--section-separation);">
+            <div class="article-content">{{ . }}</div>
+        </article>
+    {{ end }}
+
+    <section class="article-list--compact">
         {{ range $tilPosts }}
             {{ partial "article-list/default" . }}
         {{ end }}

--- a/layouts/_default/til.html
+++ b/layouts/_default/til.html
@@ -2,22 +2,25 @@
     {{ $tilPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") }}
     {{ $tilPosts := $tilPosts.ByDate.Reverse }}
 
-    <header class="page-header">
-        <h1>{{ .Title }}</h1>
-        {{ with .Params.description }}
-            <div class="page-description">{{ . }}</div>
-        {{ end }}
-    </header>
+    <section class="section-card">
+        <header>
+            <h2 class="section-term">{{ .Title }}</h2>
+            <p class="section-count" style="text-transform: none;">{{ len $tilPosts }} posts</p>
+            {{ with .Params.description }}
+                <p class="section-description">{{ . }}</p>
+            {{ end }}
+        </header>
 
-    {{ with .Content }}
-        <article style="margin-bottom: var(--section-separation);">
-            <div class="article-content">{{ . }}</div>
-        </article>
-    {{ end }}
+        {{ with .Content }}
+            <div class="article-content" style="margin-top: 1.5rem;">
+                {{ . }}
+            </div>
+        {{ end }}
+    </section>
 
     <section class="article-list--compact">
         {{ range $tilPosts }}
-            {{ partial "article-list/default" . }}
+            {{ partial "article-list/compact" . }}
         {{ end }}
     </section>
 

--- a/layouts/_default/til.html
+++ b/layouts/_default/til.html
@@ -1,0 +1,30 @@
+{{ define "main" }}
+    <article class="main-article">
+        <header class="article-header">
+            <h1 class="article-title">{{ .Title }}</h1>
+            {{ if .Params.description }}
+            <p class="article-subtitle">{{ .Params.description }}</p>
+            {{ end }}
+        </header>
+
+        <section class="article-content">
+            {{ .Content }}
+        </section>
+    </article>
+
+    {{ $tilPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") }}
+    {{ $tilPosts := $tilPosts.ByDate.Reverse }}
+
+    <section class="article-list" style="margin-top: 2rem;">
+        <h2>All TIL Posts ({{ len $tilPosts }})</h2>
+        {{ range $tilPosts }}
+            {{ partial "article-list/default" . }}
+        {{ end }}
+    </section>
+
+    {{- partial "footer/footer" . -}}
+{{ end }}
+
+{{ define "right-sidebar" }}
+    {{ partial "sidebar/right.html" (dict "Context" . "Scope" "page") }}
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,8 @@
 {{ define "main" }}
     {{ $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
     {{ $notHidden := where .Site.RegularPages "Params.hidden" "!=" true }}
-    {{ $filtered := ($pages | intersect $notHidden) }}
+    {{ $notTIL := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") "==" 0 }}
+    {{ $filtered := ($pages | intersect $notHidden | intersect $notTIL) }}
 
     {{ $pinnedPages := where $filtered "Params.pinned" true }}
     {{ $unpinnedPages := where $filtered "Params.pinned" "!=" true }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,9 @@
 {{ define "main" }}
     {{ $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
     {{ $notHidden := where .Site.RegularPages "Params.hidden" "!=" true }}
-    {{ $notTIL := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") "==" 0 }}
-    {{ $filtered := ($pages | intersect $notHidden | intersect $notTIL) }}
+    {{ $tilPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "Today I Learned") }}
+    {{ $pagesNotHidden := ($pages | intersect $notHidden) }}
+    {{ $filtered := $pagesNotHidden | complement $tilPosts }}
 
     {{ $pinnedPages := where $filtered "Params.pinned" true }}
     {{ $unpinnedPages := where $filtered "Params.pinned" "!=" true }}


### PR DESCRIPTION
- Modified homepage to exclude TIL posts from main feed
- Created dedicated TIL section page at /til to display all TIL posts
- Added /til slash command for easy creation of new TIL posts
- TIL posts remain as normal blog posts but are filtered from homepage

The TIL section allows for quick, bite-sized learnings to be shared
without cluttering the main blog feed.