### PR TITLE
Add article: Build for the Model Six Months from Now

### DIFF
--- a/content/post/build-for-the-model-six-months-from-now.md
+++ b/content/post/build-for-the-model-six-months-from-now.md
@@ -1,0 +1,19 @@
+---
+title: Build for the Model Six Months from Now
+date: 2026-01-30
+categories:
+  - Article
+tags:
+  - AI
+  - Software Engineering
+---
+
+Boris Cherny, who built Claude Code at Anthropic, [recently shared](https://www.youtube.com/watch?v=PTkE7eaPJvY) advice he received from Anthropic co-founder Ben Mann:
+
+> Don't build for the model of today, build for the model 6 months from now.
+
+When Cherny first developed Claude Code, it wasn't a great product. The models weren't capable enough, and he only used the tool for about 10% of his own coding. But Mann pushed him to trust the scaling laws and design for where models would be, not where they were.
+
+Six months later, with the release of Claude 3.5 Sonnet and Opus, the models caught up to the tool's design. Cherny's usage jumped to 80-90%.
+
+This is a useful mental model for anyone building AI-powered tools: if you only design for today's capabilities, your product may be obsolete by the time it ships.


### PR DESCRIPTION
## Summary
Add a new blog post about forward-thinking AI product development, featuring insights from Boris Cherny on designing tools for future model capabilities rather than current ones.

## Changes
- Added new article post: `content/post/build-for-the-model-six-months-from-now.md`
  - Discusses Ben Mann's advice to build for models 6 months in the future
  - References Claude Code's development at Anthropic as a case study
  - Highlights how designing ahead of current capabilities led to significantly improved product-market fit

## Details
The article covers a practical lesson in AI product development: designing tools based on anticipated model improvements rather than present-day limitations. It uses Claude Code as a real-world example where initial low usage (10%) became high adoption (80-90%) once models caught up to the tool's design.

