### PR TITLE
Add URL alias for Tim Hopper podcast episode

### DIFF
--- a/content/post/podcasts/getting-to-know-tim-hopper-with-brenton-mallon.md
+++ b/content/post/podcasts/getting-to-know-tim-hopper-with-brenton-mallon.md
@@ -7,6 +7,8 @@ description: In a role reversal, my friend and former colleague Brenton Mallen
 categories:
   - Podcast
 image: /images/robot-assistant.png
+aliases:
+  - /blog/getting-to-know-tim-hopper-with-brenton-mallen/
 ---
 
 ## Listen


### PR DESCRIPTION
## Summary
Added a URL alias to the Tim Hopper podcast episode post to maintain backward compatibility with the previous URL structure.

## Changes
- Added `aliases` field to the front matter of the podcast episode post
- Configured redirect from `/blog/getting-to-know-tim-hopper-with-brenton-mallen/` to the current post URL

## Details
This change ensures that any existing links or bookmarks to the old blog URL path will continue to work, preventing broken links and maintaining SEO value. The alias allows the post to be accessible from both the new and legacy URL paths.

https://claude.ai/code/session_01PW3Aq1MLfX62Uey9WozrxP