### PR TITLE
Add revised PHYS 303 small-angle approximation paper

### DIFF
--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -11,6 +11,8 @@ tags:
 description: "A paper I wrote as a Grove City College physics undergrad in 2005, revised two decades later to incorporate my professor's handwritten feedback."
 ---
 
+<link rel="stylesheet" href="/css/small-angle-viz.css">
+
 ## Abstract
 
 Most undergraduate textbooks on classical mechanics cover the simple pendulum as an example of simple harmonic motion by making a small-angle approximation that yields an amplitude-independent period. Some authors even state that the small-angle approximation is an appropriate estimation for many oscillating systems besides simple pendulums. It can be shown that this estimation will not work for many systems; in fact, there are infinitely many simple oscillating systems whose oscillation is *intrinsically* nonlinear. The periods of these systems depend on the amplitude of oscillation, so methods other than the small-angle approximation must be used to describe their motion — otherwise the resulting equations of motion may be incorrect. Where a system does yield to approximation, one or two standard techniques suffice, and a careful writer notes which ones and why. Care must be taken when evaluating oscillating systems to be sure they are correctly solved.
@@ -37,6 +39,8 @@ $$\theta = \theta_{0}\cos(\omega t + \delta), \qquad \omega = \sqrt{\frac{g}{\el
 
 and a period that is independent of the amplitude. For small angles this approximation is very close: a plot of $\theta$ versus $\sin\theta$ shows that up to about 0.5 radians the two values are almost identical. But for angles greater than this, the approximation falls apart.
 
+<div data-viz="approx"></div>
+
 ## A better approximation
 
 Millet suggests a correction to the small-angle formula. Instead of
@@ -54,6 +58,8 @@ $$\sin\theta = 2\sin\!\frac{\theta}{2}\cos\!\frac{\theta}{2},$$
 and then approximating $\sin\frac{\theta}{2} \approx \frac{\theta}{2}$ and $\cos\frac{\theta}{2} \approx \cos\frac{\theta_{0}}{2}$.
 
 Millet notes that at $\theta_{0} = 30^{\circ}$ his approximation gives a period with a percent error of 0.0075%, while the standard approximation gives an error of 1.7%. At $\theta_{0} = 90^{\circ}$ his approximation has an error of 0.75% and the standard approximation an error of 15%. He strongly suggests that this new formula be included in textbooks, so that students "will be able to find more realistic values for some current textbook problems" (Millet 163).
+
+<div data-viz="pendulum"></div>
 
 ## The exact solution
 
@@ -79,6 +85,8 @@ $$\tau = 2\pi\sqrt{\frac{\ell}{g}}\left(1 + \frac{1}{16}\theta_{0}^{2} + \frac{1
 
 This form clearly shows how the small-angle approximation functions. For example, in calculating the period of a pendulum with a maximum oscillation of fifteen degrees, the last two terms in the parenthesis total about 0.0042, which is clearly dominated by the leading $1$.
 
+<div data-viz="period"></div>
+
 ## Intrinsically nonlinear oscillators
 
 While the simple pendulum can be correctly estimated for small angles, there turn out to be infinitely many systems for which the approximation is not at all accurate. In his paper "Theory and Examples of Intrinsically Nonlinear Oscillators," Mohazzabi demonstrates this fact. He begins by explaining that the potential energy of an oscillator — assuming it is continuous at its equilibrium point ($x = 0$) and that the potential energy there is zero — is given by
@@ -94,6 +102,8 @@ The total energy of the system is therefore
 $$E = \frac{1}{2}\left[m\left(\frac{dx}{dt}\right)^{2} + V_{0}^{(2)}x^{2} + \frac{1}{3}V_{0}^{(3)}x^{3} + \cdots\right],$$
 
 which is equivalent to the equation for harmonic oscillation when the third- and higher-order terms of the potential-energy series vanish and the equation is differentiated with respect to time. But, Mohazzabi notes, this cannot always be taken as true or even approximately true. First, it is not always the case that the potential-energy function of an oscillating system can be expanded about its equilibrium configuration in a Taylor series. Second, even when such an expansion is possible, there are cases where the coefficient of the quadratic term vanishes and the series begins with a term higher than second order (Mohazzabi 492). This is the inadequacy of the small-angle approximation: some highly regarded texts even claim, incorrectly, that all oscillators can be estimated with it — Mohazzabi cites *Classical Mechanics* by Barger and Olsson as an example.
+
+<div data-viz="potential"></div>
 
 ### A tethered mass
 
@@ -156,3 +166,5 @@ Mohazzabi, Pirooz. "[Theory and Examples of Intrinsically Nonlinear Oscillators]
 Thornton, Stephen T., and Jerry B. Marion. *[Classical Dynamics of Particles and Systems](https://openlibrary.org/books/OL3696658M).* Ch. 4, "Nonlinear Oscillations." Belmont: Thomson Brooks/Cole, 2004.
 
 Tipler, Paul A., and Gene Mosca. *[Physics for Scientists and Engineers](https://openlibrary.org/search?q=Tipler+Mosca+Physics+for+Scientists+and+Engineers),* vol. 1B, p. 441. New York: W. H. Freeman, 2004.
+
+<script src="/js/small-angle-viz.js" defer></script>

--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -1,0 +1,161 @@
+---
+title: "The Shortcomings of the Small Angle Approximation for Oscillating Systems"
+date: 2026-07-24
+slug: small-angle-approximation
+draft: true
+math: true
+categories:
+  - Article
+tags:
+  - physics
+  - mathematics
+description: "A paper I wrote as a Grove City College physics undergrad in 2005, revised two decades later to incorporate my professor's handwritten feedback."
+---
+
+> *This is a paper I wrote in December 2005 for Classical Mechanics (PHYS&nbsp;303) at Grove City College. I recently came across the graded copy — 93/100, "Great job, Tim," and dense red-pen notes in the margins — and revised it to incorporate my professor's feedback: tightening the prose, putting the sources in my own words instead of block-quoting them, defining terms more carefully, and cleaning up the citations, all as he suggested. The physics is unchanged.*
+
+## Abstract
+
+Most undergraduate textbooks on classical mechanics cover the simple pendulum as an example of simple harmonic motion by making a small-angle approximation that yields an amplitude-independent period. Some authors even state that the small-angle approximation is an appropriate estimation for many oscillating systems besides simple pendulums. It can be shown that this estimation will not work for many systems; in fact, there are infinitely many simple oscillating systems whose oscillation is *intrinsically* nonlinear. The periods of these systems depend on the amplitude of oscillation, so methods other than the small-angle approximation must be used to describe their motion — otherwise the resulting equations of motion may be incorrect. Where a system does yield to approximation, one or two standard techniques suffice, and a careful writer notes which ones and why. Care must be taken when evaluating oscillating systems to be sure they are correctly solved.
+
+## Introduction
+
+The simple pendulum has been an area of scientific interest for at least five hundred years. A sketch by Leonardo da Vinci from about 1500 shows a pendulum in use (Grattan-Guinness 1082). Galileo was the first to note that a pendulum could be used in keeping time, yet he did not seem to realize that the period of a simple pendulum is amplitude dependent. Simple harmonic motion is now a standard subject in undergraduate mechanics at both the freshman and upperclassman level, and its classic problems are the mass suspended on a spring and the simple pendulum. In solving the differential equation that describes the motion of a simple pendulum, an approximation must be used. Likewise, there are other similar systems that appear to need approximations for their solutions. Unfortunately, for pendulums released at a large angle from the vertical — and for many systems even at small angles — this approximation fails, and the problem must be approached by other methods.
+
+A simple pendulum has a "massless" rod of length $\ell$ connected to a mass $m$ at one end and rotating freely about a fixed, frictionless pivot at the other. Suspended in a uniform gravitational field, the pendulum at rest hangs with the mass directly below the pivot point. The force on the pendulum is described by Newton's laws as
+
+$$m\ell\frac{d^{2}\theta}{dt^{2}} = -mg\sin\theta,$$
+
+where $\theta$ is the angle between the equilibrium position of the rod and the rotated pendulum. Unfortunately, this differential equation cannot be solved analytically, and describing the pendulum's motion requires more than elementary techniques.
+
+## The classical approximation
+
+The common solution of undergraduate texts is to approximate the equation for a small value of $\theta$. For example, "For small $\theta$, $\sin\theta \approx \theta$" (Tipler 441), and most, if not all, other books include a similar statement. In such a case, the approximation makes the differential equation
+
+$$\frac{d^{2}\theta}{dt^{2}} = -\frac{g}{\ell}\,\theta,$$
+
+which — being the equation for simple harmonic motion — is readily solved. The solution yields an equation of motion for a simple harmonic oscillator,
+
+$$\theta = \theta_{0}\cos(\omega t + \delta), \qquad \omega = \sqrt{\frac{g}{\ell}},$$
+
+and a period that is independent of the amplitude. For small angles this approximation is very close: a plot of $\theta$ versus $\sin\theta$ shows that up to about 0.5 radians the two values are almost identical. But for angles greater than this, the approximation falls apart.
+
+## A better approximation
+
+Millet suggests a correction to the small-angle formula. Instead of
+
+$$\sin\theta \approx \theta,$$
+
+Millet uses
+
+$$\sin\theta \approx \theta\cos\!\left(\frac{\theta_{0}}{2}\right),$$
+
+where $\theta_{0}$ is the maximum angle of oscillation. This approximation is derived by noting that
+
+$$\sin\theta = 2\sin\!\frac{\theta}{2}\cos\!\frac{\theta}{2},$$
+
+and then approximating $\sin\frac{\theta}{2} \approx \frac{\theta}{2}$ and $\cos\frac{\theta}{2} \approx \cos\frac{\theta_{0}}{2}$.
+
+Millet notes that at $\theta_{0} = 30^{\circ}$ his approximation gives a period with a percent error of 0.0075%, while the standard approximation gives an error of 1.7%. At $\theta_{0} = 90^{\circ}$ his approximation has an error of 0.75% and the standard approximation an error of 15%. He strongly suggests that this new formula be included in textbooks, so that students "will be able to find more realistic values for some current textbook problems" (Millet 163).
+
+## The exact solution
+
+In *Classical Dynamics*, Thornton and Marion provide a discourse on the exact solution in a chapter on nonlinear oscillations. By calculating the potential energy at the point of maximum oscillation, they show that the differential equation can be expressed in the form
+
+$$\dot{\theta} = 2\sqrt{\frac{g}{\ell}}\,\sqrt{\sin^{2}\!\frac{\theta_{0}}{2} - \sin^{2}\!\frac{\theta}{2}}\,,$$
+
+from which the period can be found:
+
+$$\tau = 2\sqrt{\frac{\ell}{g}}\int_{0}^{\theta_{0}}\left[\sin^{2}\!\frac{\theta_{0}}{2} - \sin^{2}\!\frac{\theta}{2}\right]^{-1/2}d\theta.$$
+
+But this equation for the period is an elliptic integral of the first kind, which cannot be evaluated without numerical methods. To recast it, Thornton and Marion make the substitution
+
+$$z = \frac{\sin(\theta/2)}{\sin(\theta_{0}/2)}, \qquad k = \sin\!\frac{\theta_{0}}{2}, \qquad dz = \frac{\cos(\theta/2)}{2\sin(\theta_{0}/2)}\,d\theta = \frac{\sqrt{1-k^{2}z^{2}}}{2k}\,d\theta,$$
+
+which puts the period in the form
+
+$$\tau = 4\sqrt{\frac{\ell}{g}}\int_{0}^{1}\left[(1-z^{2})(1-k^{2}z^{2})\right]^{-1/2}dz.$$
+
+Then, with a power-series expansion and some algebra, the period becomes
+
+$$\tau = 2\pi\sqrt{\frac{\ell}{g}}\left(1 + \frac{1}{16}\theta_{0}^{2} + \frac{11}{3072}\theta_{0}^{4} + \cdots\right).$$
+
+This form clearly shows how the small-angle approximation functions. For example, in calculating the period of a pendulum with a maximum oscillation of fifteen degrees, the last two terms in the parenthesis total about 0.0042, which is clearly dominated by the leading $1$.
+
+## Intrinsically nonlinear oscillators
+
+While the simple pendulum can be correctly estimated for small angles, there turn out to be infinitely many systems for which the approximation is not at all accurate. In his paper "Theory and Examples of Intrinsically Nonlinear Oscillators," Mohazzabi demonstrates this fact. He begins by explaining that the potential energy of an oscillator — assuming it is continuous at its equilibrium point ($x = 0$) and that the potential energy there is zero — is given by
+
+$$V(x) = V_{0}^{(1)}x + \frac{1}{2}V_{0}^{(2)}x^{2} + \cdots.$$
+
+Because the potential energy at a stable equilibrium point is a local minimum, the power series must begin with an even function; that is,
+
+$$V(x) = \frac{1}{2}V_{0}^{(2)}x^{2} + \frac{1}{6}V_{0}^{(3)}x^{3} + \cdots.$$
+
+The total energy of the system is therefore
+
+$$E = \frac{1}{2}\left[m\left(\frac{dx}{dt}\right)^{2} + V_{0}^{(2)}x^{2} + \frac{1}{3}V_{0}^{(3)}x^{3} + \cdots\right],$$
+
+which is equivalent to the equation for harmonic oscillation when the third- and higher-order terms of the potential-energy series vanish and the equation is differentiated with respect to time. But, Mohazzabi notes, this cannot always be taken as true or even approximately true. First, it is not always the case that the potential-energy function of an oscillating system can be expanded about its equilibrium configuration in a Taylor series. Second, even when such an expansion is possible, there are cases where the coefficient of the quadratic term vanishes and the series begins with a term higher than second order (Mohazzabi 492). This is the inadequacy of the small-angle approximation: some highly regarded texts even claim, incorrectly, that all oscillators can be estimated with it — Mohazzabi cites *Classical Mechanics* by Barger and Olsson as an example.
+
+### A tethered mass
+
+The typical example of an intrinsically nonlinear oscillator is a mass tethered above and below by identical springs of constant $k$ and relaxed length $\ell_{0}$. For simplicity, gravity is not present in this example. If $x$ is the displacement of the particle from equilibrium, Mohazzabi calculates the potential energy of the particle as
+
+$$V(x) = k(\ell - \ell_{0})^{2} = k\ell_{0}^{2}\left[\sqrt{1 + \left(\tfrac{x}{\ell_{0}}\right)^{2}} - 1\right]^{2} = k\ell_{0}^{2}\left[\frac{1}{4}\left(\tfrac{x}{\ell_{0}}\right)^{4} - \frac{1}{8}\left(\tfrac{x}{\ell_{0}}\right)^{6} + \cdots\right]. \tag{1}$$
+
+It is clear that this system is not a simple harmonic oscillator, because the lowest power of $x$ is four, not two; therefore the estimation used for a simple pendulum will not work. Equivalent to this situation, one can imagine a block at the end of a spring, tethered to a frictionless surface so that it moves only in the $x$-direction.
+
+### Two charged rings
+
+Next, Mohazzabi provides an example from electrodynamics. He considers two thin concentric circular rings of radii $R$ and $\alpha R$, with $\alpha > 1$, lying in the $xy$-plane. Electric charges $Q$ and $-\beta Q$ (with $\beta > 0$) are uniformly distributed over the two rings, and a particle of mass $m$ and charge $q$ is placed on the $z$-axis near the center of the rings ($z \ll R$) and released (Mohazzabi 494). The potential energy of this system is
+
+$$V(z) = \frac{3Qq}{32\pi\epsilon_{0}R^{5}}\left(1 - \frac{1}{\alpha^{2}}\right)z^{4}. \tag{2}$$
+
+Once again the leading power is four, not two, so the motion of the particle is intrinsically nonlinear.
+
+### A tunnel through a sphere
+
+Mohazzabi also gives an example reminiscent of a favorite problem in elementary gravitational field theory. He considers a sphere of radius $R$ with a small tunnel along an axis through its center, into which a small mass is dropped. The sphere has a radially symmetric mass distribution with density
+
+$$\rho = \rho_{0}\left(\frac{r}{R}\right)^{s}, \qquad (\rho_{0} > 0,\; s > -2), \tag{3}$$
+
+and total mass $M$. If $s = 0$, the mass is uniform and the particle oscillates in simple harmonic motion — the familiar textbook case. In general, though, the potential energy is
+
+$$V(r) = \frac{GMm}{(s+2)R}\left(\frac{|x|}{R}\right)^{s+2}, \qquad (r \le R). \tag{4}$$
+
+For all values of $s$ not equal to zero, the motion is, once again, intrinsically nonlinear.
+
+### A bouncing ball
+
+The paper also gives an example where the potential cannot be expanded in a Taylor series at all. When an elastic ball bounces freely up and down on a horizontal plane, the potential energy (taking $x$ positive upward) is
+
+$$V(x) = mgx \;\; (x \ge 0), \qquad V(x) = \infty \;\; (x < 0). \tag{5}$$
+
+This function has a minimum at $x = 0$, but it has a sharp corner there and so is not smoothly continuous — it is not differentiable at that point. Because it is not differentiable, the Taylor series cannot be expanded about it.
+
+### A bead on a wire
+
+A fifth example imagines a bead sliding along a wire of shape $y = c|x|^{n}$, where $c$ and $n$ are constants. For small oscillations of the particle on this curve, using the differential relation $ds^{2} = dx^{2} + dy^{2}$, one can verify that along the curve the gravitational potential energy $V(y) = mgy$ can be written as $V(s) = mgc|s|^{n}$, so that the total energy of the particle is
+
+$$\frac{1}{2}m\dot{s}^{2} + V(s) = E \tag{6}$$
+
+(Mohazzabi 496). This is simple harmonic when $n = 2$, but for all other values of $n$ it is, once again, inherently nonlinear.
+
+## Conclusion
+
+The small-angle approximation is a powerful tool in physics, but it must be used only in very specific circumstances. It accurately describes a simple pendulum oscillating at an angle of less than about fifteen degrees, but it must not be used for larger oscillations. There are also other systems that cannot be described by the small-angle approximation even for small angles of oscillation. In fact, as Mohazzabi shows, there are infinitely many systems for which the approximation cannot be used at all.
+
+## Works Cited
+
+Cadwell, L. H., and E. R. Boyko. "Linearization of the Simple Pendulum." *American Journal of Physics*, Nov. 1991.
+
+Grattan-Guinness, I. *Companion Encyclopedia of the History and Philosophy of the Mathematical Sciences.* New York: Routledge, 1994.
+
+Millet, L. Edwards. "The Large-Angle Pendulum Period." *The Physics Teacher*, Mar. 2003, p. 163.
+
+Mohazzabi, Pirooz. "Theory and Examples of Intrinsically Nonlinear Oscillators." *American Journal of Physics*, Apr. 2004, pp. 492–498.
+
+Thornton, Stephen T., and Jerry B. Marion. *Classical Dynamics of Particles and Systems.* Ch. 4, "Nonlinear Oscillations." Belmont: Thomson, 2004.
+
+Tipler, Paul A., and Gene Mosca. *Physics for Scientists and Engineers,* vol. 1B, p. 441. New York: Freeman, 2004.

--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -39,8 +39,6 @@ $$\theta = \theta_{0}\cos(\omega t + \delta), \qquad \omega = \sqrt{\frac{g}{\el
 
 and a period that is independent of the amplitude. For small angles this approximation is very close: a plot of $\theta$ versus $\sin\theta$ shows that up to about 0.5 radians the two values are almost identical. But for angles greater than this, the approximation falls apart.
 
-<div data-viz="approx"></div>
-
 ## A better approximation
 
 Millet suggests a correction to the small-angle formula. Instead of
@@ -85,8 +83,6 @@ $$\tau = 2\pi\sqrt{\frac{\ell}{g}}\left(1 + \frac{1}{16}\theta_{0}^{2} + \frac{1
 
 This form clearly shows how the small-angle approximation functions. For example, in calculating the period of a pendulum with a maximum oscillation of fifteen degrees, the last two terms in the parenthesis total about 0.0042, which is clearly dominated by the leading $1$.
 
-<div data-viz="period"></div>
-
 ## Intrinsically nonlinear oscillators
 
 While the simple pendulum can be correctly estimated for small angles, there turn out to be infinitely many systems for which the approximation is not at all accurate. In his paper "Theory and Examples of Intrinsically Nonlinear Oscillators," Mohazzabi demonstrates this fact. He begins by explaining that the potential energy of an oscillator — assuming it is continuous at its equilibrium point ($x = 0$) and that the potential energy there is zero — is given by
@@ -115,6 +111,15 @@ It is clear that this system is not a simple harmonic oscillator, because the lo
 
 ### Two charged rings
 
+<figure class="osc-fig"><svg viewBox="0 0 300 170" role="img" aria-label="Two concentric charged rings with a charge oscillating along the central axis.">
+<ellipse class="s" cx="150" cy="98" rx="115" ry="26"/><ellipse class="s" cx="150" cy="98" rx="60" ry="14"/>
+<line class="dash" x1="150" y1="20" x2="150" y2="152"/><text x="150" y="16" text-anchor="middle" class="lbl-i">z</text>
+<line class="mv" x1="150" y1="54" x2="150" y2="74"/><polygon class="mvf" points="150,48 145,58 155,58"/>
+<line class="mv" x1="150" y1="122" x2="150" y2="142"/><polygon class="mvf" points="150,148 145,138 155,138"/>
+<circle class="mvf" cx="150" cy="98" r="5"/><text x="162" y="93" class="lbl-i" style="fill:var(--saviz-exact)">q</text>
+<text x="88" y="102" text-anchor="middle">+Q</text><text x="33" y="102" text-anchor="middle">−βQ</text>
+</svg><figcaption>Two concentric rings of radii <span class="lbl-i">R</span> and <span class="lbl-i">αR</span> carry charges +Q and −βQ; a charge <span class="lbl-i">q</span> oscillates along the axis. Tuned so β = α³, the potential is ∝ z⁴.</figcaption></figure>
+
 Next, Mohazzabi provides an example from electrodynamics. He considers two thin concentric circular rings of radii $R$ and $\alpha R$, with $\alpha > 1$, lying in the $xy$-plane. Electric charges $Q$ and $-\beta Q$ (with $\beta > 0$) are uniformly distributed over the two rings, and a particle of mass $m$ and charge $q$ is placed on the $z$-axis near the center of the rings ($z \ll R$) and released (Mohazzabi 494). When the charges are chosen so that $\beta = \alpha^{3}$, the quadratic term of the potential vanishes and its leading behavior is quartic:
 
 $$V(z) = \frac{3Qq}{32\pi\epsilon_{0}R^{5}}\left(1 - \frac{1}{\alpha^{2}}\right)z^{4}. \tag{2}$$
@@ -122,6 +127,17 @@ $$V(z) = \frac{3Qq}{32\pi\epsilon_{0}R^{5}}\left(1 - \frac{1}{\alpha^{2}}\right)
 Once again the leading power is four, not two, so the motion of the particle is intrinsically nonlinear.
 
 ### A tunnel through a sphere
+
+<figure class="osc-fig"><svg viewBox="0 0 300 205" role="img" aria-label="A sphere with a tunnel through its center and a mass dropped inside.">
+<circle class="s" cx="150" cy="100" r="78"/>
+<circle class="dash" cx="150" cy="100" r="52"/><circle class="dash" cx="150" cy="100" r="26"/>
+<line class="dash" x1="150" y1="14" x2="150" y2="186"/>
+<line class="mv" x1="150" y1="70" x2="150" y2="90"/><polygon class="mvf" points="150,96 145,86 155,86"/>
+<line class="mv" x1="150" y1="130" x2="150" y2="110"/><polygon class="mvf" points="150,104 145,114 155,114"/>
+<circle class="mvf" cx="150" cy="100" r="5.5"/><text x="163" y="95" class="lbl-i" style="fill:var(--saviz-exact)">m</text>
+<line class="s" x1="150" y1="100" x2="215" y2="67"/><text x="197" y="72" class="lbl-i">R</text>
+<text x="150" y="200" text-anchor="middle">ρ ∝ (r/R)ˢ</text>
+</svg><figcaption>A mass dropped through a tunnel in a sphere whose density varies as <span class="lbl-i">ρ ∝ (r/R)ˢ</span>. Only <span class="lbl-i">s</span> = 0 (uniform density) gives simple harmonic motion.</figcaption></figure>
 
 Mohazzabi also gives an example reminiscent of a favorite problem in elementary gravitational field theory. He considers a sphere of radius $R$ with a small tunnel along an axis through its center, into which a small mass is dropped. The sphere has a radially symmetric mass distribution with density
 
@@ -135,6 +151,14 @@ For all values of $s$ not equal to zero, the motion is, once again, intrinsicall
 
 ### A bouncing ball
 
+<figure class="osc-fig"><svg viewBox="0 0 300 165" role="img" aria-label="A ball bouncing on a horizontal floor under gravity.">
+<line class="s" x1="58" y1="140" x2="242" y2="140"/>
+<line class="s" x1="64" y1="140" x2="56" y2="150"/><line class="s" x1="84" y1="140" x2="76" y2="150"/><line class="s" x1="104" y1="140" x2="96" y2="150"/><line class="s" x1="124" y1="140" x2="116" y2="150"/><line class="s" x1="144" y1="140" x2="136" y2="150"/><line class="s" x1="164" y1="140" x2="156" y2="150"/><line class="s" x1="184" y1="140" x2="176" y2="150"/><line class="s" x1="204" y1="140" x2="196" y2="150"/><line class="s" x1="224" y1="140" x2="216" y2="150"/>
+<circle class="mvf" cx="150" cy="58" r="15"/><text x="150" y="62" text-anchor="middle" style="fill:var(--card-background)">m</text>
+<line class="dash" x1="118" y1="58" x2="118" y2="140"/><text x="110" y="103" text-anchor="end" class="lbl-i">x</text>
+<line class="mv" x1="190" y1="48" x2="190" y2="82"/><polygon class="mvf" points="190,88 185,78 195,78"/><text x="202" y="70" style="fill:var(--saviz-exact)" class="lbl-i">g</text>
+</svg><figcaption>A ball under gravity has <span class="lbl-i">V = mgx</span> for x ≥ 0: a sharp corner at the floor, so no Taylor series can be written about the minimum.</figcaption></figure>
+
 The paper also gives an example where the potential cannot be expanded in a Taylor series at all. When an elastic ball bounces freely up and down on a horizontal plane, the potential energy (taking $x$ positive upward) is
 
 $$V(x) = mgx \;\; (x \ge 0), \qquad V(x) = \infty \;\; (x < 0). \tag{5}$$
@@ -142,6 +166,14 @@ $$V(x) = mgx \;\; (x \ge 0), \qquad V(x) = \infty \;\; (x < 0). \tag{5}$$
 This function has a minimum at $x = 0$, but it has a sharp corner there and so is not smoothly continuous — it is not differentiable at that point. Because it is not differentiable, the Taylor series cannot be expanded about it.
 
 ### A bead on a wire
+
+<figure class="osc-fig"><svg viewBox="0 0 300 170" role="img" aria-label="A bead sliding on a curved wire under gravity.">
+<path class="s" d="M40,38 C88,42 122,150 150,150 C178,150 212,42 260,38"/>
+<line class="dash" x1="150" y1="150" x2="150" y2="28"/>
+<circle class="mvf" cx="184" cy="117" r="6"/><text x="195" y="114" class="lbl-i" style="fill:var(--saviz-exact)">m</text>
+<line class="mv" x1="184" y1="129" x2="184" y2="151"/><polygon class="mvf" points="184,155 179,145 189,145"/>
+<text x="250" y="32" text-anchor="middle" class="lbl-i">y = c|x|ⁿ</text>
+</svg><figcaption>A bead sliding on the wire <span class="lbl-i">y = c|x|ⁿ</span>. Its potential energy is ∝ |s|ⁿ, simple-harmonic only when n = 2.</figcaption></figure>
 
 A fifth example imagines a bead sliding along a wire of shape $y = c|x|^{n}$, where $c$ and $n$ are constants. For small oscillations of the particle on this curve, using the differential relation $ds^{2} = dx^{2} + dy^{2}$, one can verify that along the curve the gravitational potential energy $V(y) = mgy$ can be written as $V(s) = mgc|s|^{n}$, so that the total energy of the particle is
 

--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -1,6 +1,6 @@
 ---
 title: "The Shortcomings of the Small Angle Approximation for Oscillating Systems"
-date: 2026-07-24
+date: 2005-12-13
 slug: small-angle-approximation
 draft: true
 math: true
@@ -11,8 +11,6 @@ tags:
   - mathematics
 description: "A paper I wrote as a Grove City College physics undergrad in 2005, revised two decades later to incorporate my professor's handwritten feedback."
 ---
-
-> *This is a paper I wrote in December 2005 for Classical Mechanics (PHYS&nbsp;303) at Grove City College. I recently came across the graded copy — 93/100, "Great job, Tim," and dense red-pen notes in the margins — and revised it to incorporate my professor's feedback: tightening the prose, putting the sources in my own words instead of block-quoting them, defining terms more carefully, and cleaning up the citations, all as he suggested. The physics is unchanged.*
 
 ## Abstract
 

--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -108,7 +108,7 @@ It is clear that this system is not a simple harmonic oscillator, because the lo
 
 ### Two charged rings
 
-Next, Mohazzabi provides an example from electrodynamics. He considers two thin concentric circular rings of radii $R$ and $\alpha R$, with $\alpha > 1$, lying in the $xy$-plane. Electric charges $Q$ and $-\beta Q$ (with $\beta > 0$) are uniformly distributed over the two rings, and a particle of mass $m$ and charge $q$ is placed on the $z$-axis near the center of the rings ($z \ll R$) and released (Mohazzabi 494). The potential energy of this system is
+Next, Mohazzabi provides an example from electrodynamics. He considers two thin concentric circular rings of radii $R$ and $\alpha R$, with $\alpha > 1$, lying in the $xy$-plane. Electric charges $Q$ and $-\beta Q$ (with $\beta > 0$) are uniformly distributed over the two rings, and a particle of mass $m$ and charge $q$ is placed on the $z$-axis near the center of the rings ($z \ll R$) and released (Mohazzabi 494). When the charges are chosen so that $\beta = \alpha^{3}$, the quadratic term of the potential vanishes and its leading behavior is quartic:
 
 $$V(z) = \frac{3Qq}{32\pi\epsilon_{0}R^{5}}\left(1 - \frac{1}{\alpha^{2}}\right)z^{4}. \tag{2}$$
 

--- a/content/post/small-angle-approximation.md
+++ b/content/post/small-angle-approximation.md
@@ -2,7 +2,6 @@
 title: "The Shortcomings of the Small Angle Approximation for Oscillating Systems"
 date: 2005-12-13
 slug: small-angle-approximation
-draft: true
 math: true
 categories:
   - Article
@@ -146,14 +145,14 @@ The small-angle approximation is a powerful tool in physics, but it must be used
 
 ## Works Cited
 
-Cadwell, L. H., and E. R. Boyko. "Linearization of the Simple Pendulum." *American Journal of Physics*, Nov. 1991.
+Cadwell, L. H., and E. R. Boyko. "[Linearization of the Simple Pendulum](https://doi.org/10.1119/1.16655)." *American Journal of Physics*, vol. 59, no. 11, 1991, pp. 979–981.
 
 Grattan-Guinness, I. *Companion Encyclopedia of the History and Philosophy of the Mathematical Sciences.* New York: Routledge, 1994.
 
-Millet, L. Edwards. "The Large-Angle Pendulum Period." *The Physics Teacher*, Mar. 2003, p. 163.
+Millet, L. Edward. "[The Large-Angle Pendulum Period](https://doi.org/10.1119/1.1557505)." *The Physics Teacher*, vol. 41, no. 3, 2003, pp. 162–163.
 
-Mohazzabi, Pirooz. "Theory and Examples of Intrinsically Nonlinear Oscillators." *American Journal of Physics*, Apr. 2004, pp. 492–498.
+Mohazzabi, Pirooz. "[Theory and Examples of Intrinsically Nonlinear Oscillators](https://doi.org/10.1119/1.1624114)." *American Journal of Physics*, vol. 72, no. 4, 2004, pp. 492–498.
 
-Thornton, Stephen T., and Jerry B. Marion. *Classical Dynamics of Particles and Systems.* Ch. 4, "Nonlinear Oscillations." Belmont: Thomson, 2004.
+Thornton, Stephen T., and Jerry B. Marion. *[Classical Dynamics of Particles and Systems](https://openlibrary.org/books/OL3696658M).* Ch. 4, "Nonlinear Oscillations." Belmont: Thomson Brooks/Cole, 2004.
 
-Tipler, Paul A., and Gene Mosca. *Physics for Scientists and Engineers,* vol. 1B, p. 441. New York: Freeman, 2004.
+Tipler, Paul A., and Gene Mosca. *[Physics for Scientists and Engineers](https://openlibrary.org/search?q=Tipler+Mosca+Physics+for+Scientists+and+Engineers),* vol. 1B, p. 441. New York: W. H. Freeman, 2004.

--- a/static/css/small-angle-viz.css
+++ b/static/css/small-angle-viz.css
@@ -1,0 +1,115 @@
+/* Interactive visualizations for "The Shortcomings of the Small Angle Approximation".
+   Self-contained, theme-aware (reads the Stack theme's data-scheme). */
+
+.saviz {
+  --saviz-exact:  #3b7df0;   /* exact solution      */
+  --saviz-millet: #16a085;   /* Millet correction   */
+  --saviz-small:  #e8853b;   /* small-angle approx  */
+  --saviz-alert:  #e0553e;   /* error / emphasis    */
+  --saviz-neutral: #9aa4b0;
+
+  margin: 2.2em 0;
+  padding: 18px 18px 16px;
+  border: 1px solid var(--card-separator-color, rgba(128,128,128,0.25));
+  border-radius: 12px;
+  background: var(--card-background, #fff);
+  color: var(--card-text-color-main, #111);
+  box-shadow: var(--shadow-l1, 0 1px 3px rgba(0,0,0,0.08));
+  font-size: 1.4rem;
+  line-height: 1.5;
+}
+
+.saviz__title {
+  font-weight: 700;
+  font-size: 1.1em;
+  margin: 0 0 2px;
+  letter-spacing: -0.01em;
+}
+.saviz__sub {
+  margin: 0 0 14px;
+  color: var(--card-text-color-secondary, #666);
+  font-size: 0.92em;
+}
+
+.saviz__canvas-wrap { position: relative; width: 100%; }
+.saviz canvas { display: block; width: 100%; height: auto; touch-action: none; }
+
+.saviz__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 22px;
+  align-items: center;
+  margin-top: 14px;
+}
+.saviz__control { display: flex; flex-direction: column; gap: 4px; min-width: 190px; flex: 1 1 210px; }
+.saviz__control label {
+  font-size: 0.82em;
+  color: var(--card-text-color-secondary, #666);
+  display: flex; justify-content: space-between; gap: 10px;
+}
+.saviz__control label b { color: var(--card-text-color-main, #111); font-variant-numeric: tabular-nums; }
+
+.saviz input[type=range] {
+  -webkit-appearance: none; appearance: none;
+  width: 100%; height: 4px; border-radius: 4px;
+  background: var(--card-separator-color, #d8d8d8);
+  outline: none; margin: 6px 0;
+}
+.saviz input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 17px; height: 17px; border-radius: 50%;
+  background: var(--saviz-exact); cursor: pointer;
+  border: 2px solid var(--card-background, #fff);
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.15);
+}
+.saviz input[type=range]::-moz-range-thumb {
+  width: 15px; height: 15px; border-radius: 50%;
+  background: var(--saviz-exact); cursor: pointer; border: 2px solid var(--card-background,#fff);
+}
+
+.saviz__buttons { display: flex; gap: 8px; flex: 0 0 auto; }
+.saviz__btn {
+  font: inherit; font-size: 0.86em; font-weight: 600;
+  padding: 6px 14px; border-radius: 7px; cursor: pointer;
+  border: 1px solid var(--card-separator-color, #ccc);
+  background: var(--card-background-selected, #eee);
+  color: var(--card-text-color-main, #111);
+}
+.saviz__btn:hover { border-color: var(--saviz-exact); }
+.saviz__btn:active { transform: translateY(1px); }
+
+.saviz__readout {
+  display: grid; gap: 8px 18px; margin-top: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+.saviz__stat {
+  padding: 9px 11px; border-radius: 8px;
+  background: var(--blockquote-background-color, rgba(128,128,128,0.08));
+}
+.saviz__stat .k { font-size: 0.76em; color: var(--card-text-color-secondary, #666); display:block; }
+.saviz__stat .v { font-size: 1.18em; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing:-0.01em; }
+
+.saviz__legend { display: flex; flex-wrap: wrap; gap: 6px 16px; margin: 2px 0 12px; font-size: 0.86em; }
+.saviz__legend span { display: inline-flex; align-items: center; gap: 6px; color: var(--card-text-color-secondary,#666); }
+.saviz__legend span::before {
+  content: ""; width: 15px; height: 3px; border-radius: 2px; background: currentColor;
+}
+.saviz__legend .l-exact::before  { background: var(--saviz-exact); }
+.saviz__legend .l-millet::before { background: var(--saviz-millet); }
+.saviz__legend .l-small::before  { background: var(--saviz-small); }
+.saviz__legend .l-alert::before  { background: var(--saviz-alert); }
+
+.saviz__seg { display: inline-flex; border: 1px solid var(--card-separator-color,#ccc); border-radius: 8px; overflow: hidden; }
+.saviz__seg button {
+  font: inherit; font-size: 0.84em; padding: 6px 12px; border: none; cursor: pointer;
+  background: var(--card-background, #fff); color: var(--card-text-color-secondary, #666);
+}
+.saviz__seg button[aria-pressed="true"] { background: var(--saviz-exact); color: #fff; font-weight: 600; }
+
+.saviz__note { margin: 12px 0 0; font-size: 0.9em; color: var(--card-text-color-secondary, #666); }
+.saviz__note b { color: var(--card-text-color-main, #111); }
+
+@media (max-width: 520px) {
+  .saviz { font-size: 1.3rem; padding: 14px; }
+  .saviz__control { min-width: 100%; }
+}

--- a/static/css/small-angle-viz.css
+++ b/static/css/small-angle-viz.css
@@ -113,3 +113,26 @@
   .saviz { font-size: 1.3rem; padding: 14px; }
   .saviz__control { min-width: 100%; }
 }
+
+/* Physical schematic diagrams (inline SVG) for the nonlinear oscillators */
+.osc-fig {
+  margin: 1.9em auto;
+  text-align: center;
+  color: var(--card-text-color-main, #111);
+}
+.osc-fig svg { width: 100%; max-width: 320px; height: auto; overflow: visible; }
+.osc-fig .s { stroke: currentColor; fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
+.osc-fig .f { fill: currentColor; stroke: none; }
+.osc-fig .dash { stroke: var(--card-text-color-secondary, #888); fill: none; stroke-width: 1.1; stroke-dasharray: 4 4; opacity: 0.65; }
+.osc-fig .mv { stroke: var(--saviz-exact, #3b7df0); fill: none; stroke-width: 1.9; }
+.osc-fig .mvf { fill: var(--saviz-exact, #3b7df0); }
+.osc-fig text { fill: currentColor; font-family: var(--sys-font-family), sans-serif; font-size: 12px; }
+.osc-fig .lbl-i { font-style: italic; }
+.osc-fig figcaption {
+  margin: 8px auto 0;
+  max-width: 460px;
+  font-size: 0.86em;
+  line-height: 1.5;
+  color: var(--card-text-color-secondary, #666);
+}
+.osc-fig figcaption .lbl-i { font-style: italic; }

--- a/static/js/small-angle-viz.js
+++ b/static/js/small-angle-viz.js
@@ -1,0 +1,540 @@
+/*
+ * Interactive visualizations for
+ * "The Shortcomings of the Small Angle Approximation for Oscillating Systems".
+ *
+ * Dependency-free. All physics is exact:
+ *   - Pendulum period via the complete elliptic integral K, evaluated with the
+ *     arithmetic-geometric mean (machine precision):  T/T0 = 1 / AGM(1, cos(theta0/2)).
+ *   - Millet / Kidd-Fogg correction:  T/T0 = 1 / sqrt(cos(theta0/2)).
+ *   - Exact large-angle motion by RK4 integration of  theta'' = -sin(theta).
+ * These reproduce the paper's error figures exactly (30 deg: 1.7% / 0.0075%; 90 deg: 15% / 0.75%).
+ */
+(function () {
+  "use strict";
+
+  /* ------------------------------------------------------------------ physics */
+  function agm(a, b) {
+    for (let i = 0; i < 100; i++) {
+      const a1 = (a + b) / 2, b1 = Math.sqrt(a * b);
+      if (Math.abs(a1 - b1) <= 1e-16 * a1) return (a1 + b1) / 2;
+      a = a1; b = b1;
+    }
+    return (a + b) / 2;
+  }
+  // Complete elliptic integral of the first kind, modulus k.
+  function ellipticK(k) { return Math.PI / (2 * agm(1, Math.sqrt(1 - k * k))); }
+
+  const Texact  = t0 => (2 / Math.PI) * ellipticK(Math.sin(t0 / 2)); // = 1/agm(1,cos(t0/2))
+  const Tmillet = t0 => 1 / Math.sqrt(Math.cos(t0 / 2));
+  const Tseries = t0 => 1 + t0 * t0 / 16 + 11 * Math.pow(t0, 4) / 3072;
+
+  const DEG = Math.PI / 180;
+  const fmtPct = x => (x >= 10 ? x.toFixed(1) : x >= 1 ? x.toFixed(2) : x.toFixed(3)) + "%";
+
+  /* -------------------------------------------------------------------- theme */
+  const redraws = [];
+  function palette(el) {
+    const cs = getComputedStyle(el);
+    const g = n => cs.getPropertyValue(n).trim();
+    return {
+      exact:  g("--saviz-exact")  || "#3b7df0",
+      millet: g("--saviz-millet") || "#16a085",
+      small:  g("--saviz-small")  || "#e8853b",
+      alert:  g("--saviz-alert")  || "#e0553e",
+      neutral:g("--saviz-neutral")|| "#9aa4b0",
+      text:   g("--card-text-color-main") || "#111",
+      dim:    g("--card-text-color-secondary") || "#666",
+      sep:    g("--card-separator-color") || "rgba(128,128,128,0.3)",
+      bg:     g("--card-background") || "#fff",
+    };
+  }
+  new MutationObserver(() => redraws.forEach(fn => { try { fn(); } catch (e) {} }))
+    .observe(document.documentElement, { attributes: true, attributeFilter: ["data-scheme"] });
+
+  /* --------------------------------------------------------------- canvas util */
+  function hidpi(canvas, cssW, cssH) {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    canvas.style.height = cssH + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return ctx;
+  }
+  // Linear map factory for a plot region in pixel space.
+  function mapper(px, py, pw, ph, xmin, xmax, ymin, ymax) {
+    return {
+      X: x => px + (x - xmin) / (xmax - xmin) * pw,
+      Y: y => py + ph - (y - ymin) / (ymax - ymin) * ph,
+      px, py, pw, ph, xmin, xmax, ymin, ymax,
+    };
+  }
+  function line(ctx, m, f, color, width, dash) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.lineWidth = width || 2;
+    ctx.strokeStyle = color;
+    ctx.setLineDash(dash || []);
+    ctx.lineJoin = "round";
+    const N = Math.max(40, Math.round(m.pw));
+    let started = false;
+    for (let i = 0; i <= N; i++) {
+      const x = m.xmin + (m.xmax - m.xmin) * i / N;
+      const y = f(x);
+      if (!isFinite(y)) { started = false; continue; }
+      const px = m.X(x), py = m.Y(Math.max(m.ymin, Math.min(m.ymax, y)));
+      if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+  function dot(ctx, x, y, r, color) {
+    ctx.beginPath(); ctx.fillStyle = color;
+    ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.fill();
+  }
+  function label(ctx, text, x, y, color, font, align, baseline) {
+    ctx.fillStyle = color;
+    ctx.font = font || "12px -apple-system, sans-serif";
+    ctx.textAlign = align || "left";
+    ctx.textBaseline = baseline || "alphabetic";
+    ctx.fillText(text, x, y);
+  }
+
+  /* ----------------------------------------------------------------- scaffold */
+  function card(mount, title, sub) {
+    mount.classList.add("saviz");
+    mount.innerHTML =
+      '<p class="saviz__title">' + title + "</p>" +
+      (sub ? '<p class="saviz__sub">' + sub + "</p>" : "") +
+      '<div class="saviz__body"></div>';
+    return mount.querySelector(".saviz__body");
+  }
+  function el(tag, cls, html) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+  function slider(min, max, step, val) {
+    const s = el("input");
+    s.type = "range"; s.min = min; s.max = max; s.step = step; s.value = val;
+    return s;
+  }
+  // Responsive: re-fit canvas to card width, call draw(ctx, w, h). Registers redraw.
+  function responsive(mount, canvas, aspect, draw) {
+    let w = 0, h = 0;
+    function relayout() {
+      const cw = Math.max(240, mount.clientWidth);
+      const ch = Math.round(cw * aspect);
+      w = cw; h = ch;
+      const ctx = hidpi(canvas, cw, ch);
+      draw(ctx, cw, ch);
+    }
+    const ro = new ResizeObserver(() => { requestAnimationFrame(relayout); });
+    ro.observe(mount);
+    redraws.push(relayout);
+    relayout();
+    return { relayout, get w() { return w; }, get h() { return h; } };
+  }
+  // Pause animation when the widget scrolls out of view.
+  function whenVisible(node, onShow, onHide) {
+    new IntersectionObserver(es => {
+      es.forEach(e => (e.isIntersecting ? onShow() : onHide()));
+    }, { threshold: 0.01 }).observe(node);
+  }
+
+  /* ============================================================ 1. theta vs sin */
+  function vizApprox(mount) {
+    const body = card(mount,
+      "The approximation itself: sin&thinsp;&theta; &asymp; &theta;",
+      "Drag the angle. The straight line is the approximation used in the textbook derivation; the curve is the truth. Watch the gap open up.");
+    body.appendChild(el("div", "saviz__legend",
+      '<span class="l-small">y = &theta; (approximation)</span>' +
+      '<span class="l-exact">y = sin&thinsp;&theta; (exact)</span>' +
+      '<span class="l-alert">error</span>'));
+    const wrap = el("div", "saviz__canvas-wrap");
+    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
+
+    const controls = el("div", "saviz__controls");
+    const c1 = el("div", "saviz__control");
+    const lab = el("label", null, '<span>Amplitude &theta;</span><b></b>');
+    const sl = slider(1, 120, 0.5, 35);
+    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
+    body.appendChild(controls);
+
+    const readout = el("div", "saviz__readout"); body.appendChild(readout);
+    readout.innerHTML =
+      '<div class="saviz__stat"><span class="k">&theta; (radians)</span><span class="v" data-r="rad"></span></div>' +
+      '<div class="saviz__stat"><span class="k">sin&thinsp;&theta;</span><span class="v" data-r="sin"></span></div>' +
+      '<div class="saviz__stat"><span class="k">relative error &theta; vs sin&thinsp;&theta;</span><span class="v" data-r="err"></span></div>';
+
+    function draw(ctx, w, h) {
+      const p = palette(mount);
+      ctx.clearRect(0, 0, w, h);
+      const t0 = +sl.value * DEG;
+      const xmax = 120 * DEG;
+      const m = mapper(46, 14, w - 62, h - 40, 0, xmax, 0, xmax);
+
+      // grid + axes
+      ctx.strokeStyle = p.sep; ctx.lineWidth = 1;
+      ctx.beginPath();
+      for (let d = 0; d <= 120; d += 30) {
+        const x = m.X(d * DEG); ctx.moveTo(x, m.py); ctx.lineTo(x, m.py + m.ph);
+        label(ctx, d + "°", x, m.py + m.ph + 15, p.dim, "11px sans-serif", "center");
+      }
+      for (let v = 0; v <= 2; v += 0.5) {
+        const y = m.Y(v); if (y < m.py) continue;
+        ctx.moveTo(m.px, y); ctx.lineTo(m.px + m.pw, y);
+        label(ctx, v.toFixed(1), m.px - 7, y, p.dim, "11px sans-serif", "right", "middle");
+      }
+      ctx.stroke();
+
+      // error band between the curves up to t0
+      ctx.save(); ctx.beginPath();
+      const N = 80;
+      for (let i = 0; i <= N; i++) { const x = t0 * i / N; ctx[i ? "lineTo" : "moveTo"](m.X(x), m.Y(x)); }
+      for (let i = N; i >= 0; i--) { const x = t0 * i / N; ctx.lineTo(m.X(x), m.Y(Math.sin(x))); }
+      ctx.closePath(); ctx.fillStyle = p.alert + "33"; ctx.fill(); ctx.restore();
+
+      line(ctx, m, x => x, p.small, 2.5);           // y = theta
+      line(ctx, m, x => Math.sin(x), p.exact, 2.5); // y = sin theta
+
+      // markers at t0
+      const yA = m.Y(t0), yS = m.Y(Math.sin(t0)), xM = m.X(t0);
+      ctx.strokeStyle = p.alert; ctx.lineWidth = 2; ctx.setLineDash([4, 4]);
+      ctx.beginPath(); ctx.moveTo(xM, yA); ctx.lineTo(xM, yS); ctx.stroke(); ctx.setLineDash([]);
+      dot(ctx, xM, yA, 4.5, p.small); dot(ctx, xM, yS, 4.5, p.exact);
+
+      const err = (t0 - Math.sin(t0)) / Math.sin(t0) * 100;
+      readout.querySelector('[data-r="rad"]').textContent = t0.toFixed(3);
+      readout.querySelector('[data-r="sin"]').textContent = Math.sin(t0).toFixed(3);
+      const ev = readout.querySelector('[data-r="err"]');
+      ev.textContent = fmtPct(err);
+      ev.style.color = err > 5 ? p.alert : err > 1 ? p.small : p.millet;
+      lab.querySelector("b").textContent = (+sl.value).toFixed(1) + "°";
+    }
+    const r = responsive(body, canvas, 0.62, draw);
+    sl.addEventListener("input", r.relayout);
+  }
+
+  /* ========================================================= 2. animated pendulum */
+  function vizPendulum(mount) {
+    const body = card(mount,
+      "See it fail: exact swing vs the textbook prediction",
+      "Both pendulums are released from rest at the same angle. Orange obeys the small-angle prediction &theta;&#8320;cos(&omega;&#8320;t); blue is the true motion. At small angles they lock together. Open the angle and the true pendulum falls behind — its period is longer.");
+    body.appendChild(el("div", "saviz__legend",
+      '<span class="l-exact">exact pendulum</span>' +
+      '<span class="l-small">small-angle prediction</span>'));
+    const wrap = el("div", "saviz__canvas-wrap");
+    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
+
+    const controls = el("div", "saviz__controls");
+    const c1 = el("div", "saviz__control");
+    const lab = el("label", null, '<span>Release angle &theta;&#8320;</span><b></b>');
+    const sl = slider(5, 175, 1, 90);
+    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
+    const btns = el("div", "saviz__buttons");
+    const bPlay = el("button", "saviz__btn", "Pause");
+    const bReset = el("button", "saviz__btn", "Reset");
+    btns.appendChild(bPlay); btns.appendChild(bReset); controls.appendChild(btns);
+    body.appendChild(controls);
+
+    const readout = el("div", "saviz__readout"); body.appendChild(readout);
+    readout.innerHTML =
+      '<div class="saviz__stat"><span class="k">true period T / T&#8320;</span><span class="v" data-r="ratio"></span></div>' +
+      '<div class="saviz__stat"><span class="k">extra time per swing</span><span class="v" data-r="extra"></span></div>' +
+      '<div class="saviz__stat"><span class="k">angle gap (exact &minus; approx)</span><span class="v" data-r="lag"></span></div>';
+
+    // simulation state (units: omega0 = 1, so small-angle period = 2*pi)
+    let th0 = +sl.value * DEG, te = th0, we = 0, t = 0;
+    const buf = []; // {t, e, s}
+    const SIM_PER_SEC = 1.7, WINDOW = 6 * Math.PI; // ~3 small-angle periods on the strip chart
+
+    function step(dt) {
+      // RK4 on [theta, omega], d/dt = [omega, -sin theta]
+      const sub = 0.004; let rem = dt;
+      while (rem > 1e-9) {
+        const s = Math.min(sub, rem); rem -= s;
+        const f = (a, w) => [w, -Math.sin(a)];
+        const k1 = f(te, we);
+        const k2 = f(te + s / 2 * k1[0], we + s / 2 * k1[1]);
+        const k3 = f(te + s / 2 * k2[0], we + s / 2 * k2[1]);
+        const k4 = f(te + s * k3[0], we + s * k3[1]);
+        te += s / 6 * (k1[0] + 2 * k2[0] + 2 * k3[0] + k4[0]);
+        we += s / 6 * (k1[1] + 2 * k2[1] + 2 * k3[1] + k4[1]);
+        t += s;
+      }
+      const ts = th0 * Math.cos(t); // small-angle prediction
+      buf.push({ t: t, e: te, s: ts });
+      while (buf.length && buf[0].t < t - WINDOW) buf.shift();
+    }
+    // Pre-roll one window so the first painted frame already shows the divergence,
+    // even when the tab is backgrounded (requestAnimationFrame throttled) or motion is reduced.
+    function reset() {
+      th0 = +sl.value * DEG; te = th0; we = 0; t = 0; buf.length = 0;
+      while (t < WINDOW) step(0.05);
+    }
+
+    function draw(ctx, w, h) {
+      const p = palette(mount);
+      ctx.clearRect(0, 0, w, h);
+      const split = Math.min(w * 0.42, h - 8);
+      // ---- left: pendulums (pivot centered so the bob fits at any angle up to 175 deg) ----
+      const cx = split / 2, pivY = h / 2, L = Math.min(split / 2 - 12, (h - 16) / 2);
+      ctx.strokeStyle = p.sep; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.arc(cx, pivY, 3, 0, 2 * Math.PI); ctx.stroke();
+      // reference vertical (equilibrium)
+      ctx.setLineDash([3, 4]); ctx.beginPath();
+      ctx.moveTo(cx, pivY); ctx.lineTo(cx, pivY + L + 6); ctx.stroke(); ctx.setLineDash([]);
+      const ts = th0 * Math.cos(t);
+      function drawP(ang, color, r) {
+        const x = cx + L * Math.sin(ang), y = pivY + L * Math.cos(ang);
+        ctx.strokeStyle = color; ctx.lineWidth = 2.5; ctx.globalAlpha = 0.95;
+        ctx.beginPath(); ctx.moveTo(cx, pivY); ctx.lineTo(x, y); ctx.stroke();
+        dot(ctx, x, y, r, color); ctx.globalAlpha = 1;
+      }
+      drawP(ts, p.small, 8);
+      drawP(te, p.exact, 8);
+
+      // ---- right: strip chart theta(t) ----
+      const gx = split + 14, gw = w - split - 22, gy = 12, gh = h - 30;
+      const amp = Math.max(th0, 0.2) * 1.05;
+      const m = mapper(gx, gy, gw, gh, t - WINDOW, t, -amp, amp);
+      ctx.strokeStyle = p.sep; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(gx, m.Y(0)); ctx.lineTo(gx + gw, m.Y(0)); ctx.stroke();
+      label(ctx, "θ(t)", gx, gy + 2, p.dim, "11px sans-serif", "left", "top");
+      function trace(key, color) {
+        ctx.beginPath(); ctx.strokeStyle = color; ctx.lineWidth = 2; let st = false;
+        for (const s of buf) {
+          const X = m.X(s.t), Y = m.Y(Math.max(-amp, Math.min(amp, s[key])));
+          if (!st) { ctx.moveTo(X, Y); st = true; } else ctx.lineTo(X, Y);
+        }
+        ctx.stroke();
+      }
+      trace("s", p.small); trace("e", p.exact);
+      // leading dots
+      if (buf.length) {
+        const last = buf[buf.length - 1];
+        dot(ctx, m.X(last.t), m.Y(Math.max(-amp, Math.min(amp, last.s))), 3.5, p.small);
+        dot(ctx, m.X(last.t), m.Y(Math.max(-amp, Math.min(amp, last.e))), 3.5, p.exact);
+      }
+
+      // readouts
+      const ratio = Texact(th0);
+      readout.querySelector('[data-r="ratio"]').textContent = ratio.toFixed(4);
+      readout.querySelector('[data-r="extra"]').textContent = "+" + fmtPct((ratio - 1) * 100);
+      // phase lag: fraction of a small-angle period between the two zero-crossings ~ (t - t*)/... approximate via angle diff
+      const lag = ((te - ts));
+      readout.querySelector('[data-r="lag"]').textContent = (lag >= 0 ? "+" : "") + lag.toFixed(2) + " rad";
+      lab.querySelector("b").textContent = (+sl.value).toFixed(0) + "°";
+    }
+
+    const r = responsive(body, canvas, 0.5, draw);
+
+    let raf = null, last = 0, running = true;
+    function frame(ts) {
+      if (!running) return;
+      if (!last) last = ts;
+      let dt = (ts - last) / 1000; last = ts;
+      dt = Math.min(dt, 0.05) * SIM_PER_SEC; // clamp tab-switch jumps
+      step(dt);
+      draw(canvas.getContext("2d"), r.w, r.h);
+      raf = requestAnimationFrame(frame);
+    }
+    function play() { if (running && raf) return; running = true; last = 0; bPlay.textContent = "Pause"; raf = requestAnimationFrame(frame); }
+    function pause() { running = false; if (raf) cancelAnimationFrame(raf); raf = null; bPlay.textContent = "Play"; }
+
+    bPlay.addEventListener("click", () => (running ? pause() : play()));
+    bReset.addEventListener("click", () => { reset(); r.relayout(); });
+    sl.addEventListener("input", () => { reset(); r.relayout(); lab.querySelector("b").textContent = (+sl.value).toFixed(0) + "°"; });
+
+    let userPaused = false;
+    whenVisible(mount,
+      () => { if (!userPaused) play(); },
+      () => { if (raf) { cancelAnimationFrame(raf); raf = null; running = false; last = 0; } });
+    // track explicit user intent so scrolling back doesn't override a manual pause
+    bPlay.addEventListener("click", () => { userPaused = !running ? false : true; });
+    reset();
+  }
+
+  /* ======================================================= 3. period vs amplitude */
+  function vizPeriod(mount) {
+    const body = card(mount,
+      "The payoff: how the period grows with amplitude",
+      "The textbook says the period never changes with amplitude (flat orange line). It does. Drag the cursor to compare the flat approximation, Millet's correction, and the exact elliptic-integral period.");
+    body.appendChild(el("div", "saviz__legend",
+      '<span class="l-small">small-angle (constant)</span>' +
+      '<span class="l-millet">Millet correction</span>' +
+      '<span class="l-exact">exact</span>'));
+    const wrap = el("div", "saviz__canvas-wrap");
+    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
+
+    const controls = el("div", "saviz__controls");
+    const c1 = el("div", "saviz__control");
+    const lab = el("label", null, '<span>Amplitude &theta;&#8320;</span><b></b>');
+    const sl = slider(1, 179, 1, 90);
+    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
+    body.appendChild(controls);
+
+    const readout = el("div", "saviz__readout"); body.appendChild(readout);
+    readout.innerHTML =
+      '<div class="saviz__stat"><span class="k">exact T / T&#8320;</span><span class="v" data-r="ex"></span></div>' +
+      '<div class="saviz__stat"><span class="k">small-angle error</span><span class="v" data-r="es"></span></div>' +
+      '<div class="saviz__stat"><span class="k">Millet error</span><span class="v" data-r="em"></span></div>';
+
+    function draw(ctx, w, h) {
+      const p = palette(mount);
+      ctx.clearRect(0, 0, w, h);
+      const xmax = 180, ymax = 2.6;
+      const m = mapper(48, 14, w - 64, h - 40, 0, xmax, 1, ymax);
+
+      ctx.strokeStyle = p.sep; ctx.lineWidth = 1; ctx.beginPath();
+      for (let d = 0; d <= 180; d += 30) {
+        const x = m.X(d); ctx.moveTo(x, m.py); ctx.lineTo(x, m.py + m.ph);
+        label(ctx, d + "°", x, m.py + m.ph + 15, p.dim, "11px sans-serif", "center");
+      }
+      for (let v = 1; v <= 2.5; v += 0.5) {
+        const y = m.Y(v); ctx.moveTo(m.px, y); ctx.lineTo(m.px + m.pw, y);
+        label(ctx, v.toFixed(1), m.px - 7, y, p.dim, "11px sans-serif", "right", "middle");
+      }
+      ctx.stroke();
+      label(ctx, "T / T₀", m.px - 7, m.py - 2, p.dim, "11px sans-serif", "right", "bottom");
+
+      line(ctx, m, () => 1, p.small, 2.5);
+      line(ctx, m, d => Tmillet(d * DEG), p.millet, 2.5);
+      line(ctx, m, d => Texact(d * DEG), p.exact, 2.5);
+
+      // reference dots from the paper (30, 90 deg)
+      [30, 90].forEach(d => dot(ctx, m.X(d), m.Y(Texact(d * DEG)), 3, p.exact));
+
+      // cursor
+      const d0 = +sl.value;
+      const xC = m.X(d0);
+      ctx.strokeStyle = p.dim; ctx.lineWidth = 1; ctx.setLineDash([4, 4]);
+      ctx.beginPath(); ctx.moveTo(xC, m.py); ctx.lineTo(xC, m.py + m.ph); ctx.stroke(); ctx.setLineDash([]);
+      const ex = Texact(d0 * DEG), mi = Tmillet(d0 * DEG);
+      dot(ctx, xC, m.Y(1), 5, p.small);
+      dot(ctx, xC, m.Y(Math.min(ymax, mi)), 5, p.millet);
+      dot(ctx, xC, m.Y(Math.min(ymax, ex)), 5, p.exact);
+
+      readout.querySelector('[data-r="ex"]').textContent = ex.toFixed(4);
+      const es = readout.querySelector('[data-r="es"]');
+      es.textContent = fmtPct(Math.abs(1 - ex) / ex * 100); es.style.color = p.small;
+      const em = readout.querySelector('[data-r="em"]');
+      em.textContent = fmtPct(Math.abs(mi - ex) / ex * 100); em.style.color = p.millet;
+      lab.querySelector("b").textContent = d0 + "°";
+    }
+    const r = responsive(body, canvas, 0.6, draw);
+    sl.addEventListener("input", r.relayout);
+  }
+
+  /* ===================================================== 4. nonlinear potentials */
+  function vizPotential(mount) {
+    const SYS = {
+      spring:   { name: "Ideal spring", V: x => x * x, one: false, shm: true,
+                  curv: "constant", verdict: "Simple harmonic ✓",
+                  note: "The textbook oscillator. The well is a parabola at every scale, so the matched parabola sits exactly on top of it." },
+      pendulum: { name: "Pendulum", V: x => 1 - Math.cos(x), one: false, shm: true,
+                  curv: "nonzero", verdict: "Simple harmonic ✓ (small &theta; only)",
+                  note: "Near the bottom V ≈ &theta;²/2, so it looks parabolic for small swings — the whole point of the paper. Zoom out and it drifts below the parabola: the period lengthens." },
+      tethered: { name: "Tethered mass (double spring)", V: x => Math.pow(Math.sqrt(1 + x * x) - 1, 2), one: false, shm: false,
+                  curv: "zero", verdict: "Intrinsically nonlinear ✗",
+                  note: "Leading term ∝ x⁴. The bottom of the well is flatter than any parabola, so no matched parabola fits — there is no small-angle regime. This is the paper's key example." },
+      ball:     { name: "Bouncing ball", V: x => (x >= 0 ? x : Infinity), one: true, shm: false,
+                  curv: "corner", verdict: "Intrinsically nonlinear ✗",
+                  note: "V = mgx has a sharp corner at x = 0 and is not differentiable there, so it has no Taylor series — the approximation can't even be written down." },
+    };
+    const order = ["spring", "pendulum", "tethered", "ball"];
+    let cur = "tethered";
+
+    const body = card(mount,
+      "Why some oscillators are <em>intrinsically</em> nonlinear",
+      "Simple harmonic motion needs a potential well shaped like a parabola at the bottom. Pick a system and zoom into its minimum. If a parabola (dashed) can hug the curve, you get SHM; if it can't, the system is nonlinear no matter how small the swing.");
+    const seg = el("div", "saviz__seg");
+    order.forEach(k => {
+      const b = el("button", null, SYS[k].name);
+      b.setAttribute("aria-pressed", k === cur ? "true" : "false");
+      b.addEventListener("click", () => { cur = k; update(); });
+      seg.appendChild(b);
+    });
+    body.appendChild(seg);
+    body.appendChild(el("div", "saviz__legend",
+      '<span class="l-exact">potential V(x)</span>' +
+      '<span class="l-small">matched parabola</span>'));
+    const wrap = el("div", "saviz__canvas-wrap");
+    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
+
+    const controls = el("div", "saviz__controls");
+    const c1 = el("div", "saviz__control");
+    const lab = el("label", null, '<span>Zoom into the minimum</span><b></b>');
+    const sl = slider(0, 100, 1, 55);
+    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
+    body.appendChild(controls);
+
+    const readout = el("div", "saviz__readout"); body.appendChild(readout);
+    readout.innerHTML =
+      '<div class="saviz__stat"><span class="k">curvature at minimum V&Prime;(0)</span><span class="v" data-r="curv"></span></div>' +
+      '<div class="saviz__stat"><span class="k">leading behavior near 0</span><span class="v" data-r="lead"></span></div>' +
+      '<div class="saviz__stat"><span class="k">verdict</span><span class="v" data-r="verdict"></span></div>';
+    const note = el("p", "saviz__note"); body.appendChild(note);
+
+    function leadPower(V) {
+      // numerically estimate exponent n from V(x) ~ x^n near 0 via log-log slope
+      const a = 1e-3, b = 4e-3;
+      return Math.log(V(b) / V(a)) / Math.log(b / a);
+    }
+
+    function draw(ctx, w, h) {
+      const p = palette(mount);
+      ctx.clearRect(0, 0, w, h);
+      const S = SYS[cur];
+      // zoom: window half-width from 2.2 down to 0.12
+      const xr = 2.2 * Math.pow(0.12 / 2.2, +sl.value / 100);
+      const xmin = S.one ? 0 : -xr, xmax = xr;
+      const Vedge = Math.max(S.V(xmax), S.one ? 0 : S.V(xmin)) || 1;
+      const m = mapper(30, 14, w - 46, h - 34, xmin, xmax, 0, Vedge * 1.08);
+
+      // axes
+      ctx.strokeStyle = p.sep; ctx.lineWidth = 1; ctx.beginPath();
+      const x0 = m.X(0); ctx.moveTo(x0, m.py); ctx.lineTo(x0, m.py + m.ph);
+      ctx.moveTo(m.px, m.py + m.ph); ctx.lineTo(m.px + m.pw, m.py + m.ph); ctx.stroke();
+      label(ctx, "x", m.px + m.pw, m.py + m.ph - 4, p.dim, "11px sans-serif", "right", "bottom");
+      label(ctx, "V", x0 + 4, m.py + 2, p.dim, "11px sans-serif", "left", "top");
+
+      // matched parabola: p(x) = Vedge*(x/xr)^2  (equals curve value at the window edge)
+      if (!S.one) line(ctx, m, x => Vedge * (x / xr) * (x / xr), p.small, 2, [6, 5]);
+      else line(ctx, m, x => Vedge * (x / xr) * (x / xr), p.small, 2, [6, 5]);
+      // potential
+      line(ctx, m, x => S.V(x), p.exact, 2.75);
+      dot(ctx, m.X(0), m.Y(0), 4, p.exact);
+
+      // readouts
+      readout.querySelector('[data-r="curv"]').textContent =
+        S.curv === "constant" ? "constant > 0" : S.curv === "nonzero" ? "> 0" : S.curv === "zero" ? "= 0" : "undefined";
+      const n = S.one ? 1 : leadPower(S.V);
+      readout.querySelector('[data-r="lead"]').innerHTML =
+        S.curv === "corner" ? "|x| (corner)" : "&asymp; x<sup>" + Math.round(n) + "</sup>";
+      const vv = readout.querySelector('[data-r="verdict"]');
+      vv.innerHTML = S.verdict; vv.style.color = S.shm ? p.millet : p.alert;
+      note.innerHTML = "<b>" + S.name + ".</b> " + S.note;
+      lab.querySelector("b").textContent = "±" + xr.toFixed(2);
+      // reflect active button
+      [...seg.children].forEach((b, i) => b.setAttribute("aria-pressed", order[i] === cur ? "true" : "false"));
+    }
+    let r;
+    function update() { if (r) r.relayout(); }
+    r = responsive(body, canvas, 0.6, draw);
+    sl.addEventListener("input", r.relayout);
+  }
+
+  /* -------------------------------------------------------------------- bootstrap */
+  const REG = { approx: vizApprox, pendulum: vizPendulum, period: vizPeriod, potential: vizPotential };
+  function boot() {
+    document.querySelectorAll("[data-viz]").forEach(node => {
+      const fn = REG[node.getAttribute("data-viz")];
+      if (fn && !node.dataset.savizReady) { node.dataset.savizReady = "1"; try { fn(node); } catch (e) { console.error("saviz", e); } }
+    });
+  }
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
+  else boot();
+})();

--- a/static/js/small-angle-viz.js
+++ b/static/js/small-angle-viz.js
@@ -143,80 +143,6 @@
     }, { threshold: 0.01 }).observe(node);
   }
 
-  /* ============================================================ 1. theta vs sin */
-  function vizApprox(mount) {
-    const body = card(mount,
-      "The approximation itself: sin&thinsp;&theta; &asymp; &theta;",
-      "Drag the angle. The straight line is the approximation used in the textbook derivation; the curve is the truth. Watch the gap open up.");
-    body.appendChild(el("div", "saviz__legend",
-      '<span class="l-small">y = &theta; (approximation)</span>' +
-      '<span class="l-exact">y = sin&thinsp;&theta; (exact)</span>' +
-      '<span class="l-alert">error</span>'));
-    const wrap = el("div", "saviz__canvas-wrap");
-    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
-
-    const controls = el("div", "saviz__controls");
-    const c1 = el("div", "saviz__control");
-    const lab = el("label", null, '<span>Amplitude &theta;</span><b></b>');
-    const sl = slider(1, 120, 0.5, 35);
-    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
-    body.appendChild(controls);
-
-    const readout = el("div", "saviz__readout"); body.appendChild(readout);
-    readout.innerHTML =
-      '<div class="saviz__stat"><span class="k">&theta; (radians)</span><span class="v" data-r="rad"></span></div>' +
-      '<div class="saviz__stat"><span class="k">sin&thinsp;&theta;</span><span class="v" data-r="sin"></span></div>' +
-      '<div class="saviz__stat"><span class="k">relative error &theta; vs sin&thinsp;&theta;</span><span class="v" data-r="err"></span></div>';
-
-    function draw(ctx, w, h) {
-      const p = palette(mount);
-      ctx.clearRect(0, 0, w, h);
-      const t0 = +sl.value * DEG;
-      const xmax = 120 * DEG;
-      const m = mapper(46, 14, w - 62, h - 40, 0, xmax, 0, xmax);
-
-      // grid + axes
-      ctx.strokeStyle = p.sep; ctx.lineWidth = 1;
-      ctx.beginPath();
-      for (let d = 0; d <= 120; d += 30) {
-        const x = m.X(d * DEG); ctx.moveTo(x, m.py); ctx.lineTo(x, m.py + m.ph);
-        label(ctx, d + "°", x, m.py + m.ph + 15, p.dim, "11px sans-serif", "center");
-      }
-      for (let v = 0; v <= 2; v += 0.5) {
-        const y = m.Y(v); if (y < m.py) continue;
-        ctx.moveTo(m.px, y); ctx.lineTo(m.px + m.pw, y);
-        label(ctx, v.toFixed(1), m.px - 7, y, p.dim, "11px sans-serif", "right", "middle");
-      }
-      ctx.stroke();
-
-      // error band between the curves up to t0
-      ctx.save(); ctx.beginPath();
-      const N = 80;
-      for (let i = 0; i <= N; i++) { const x = t0 * i / N; ctx[i ? "lineTo" : "moveTo"](m.X(x), m.Y(x)); }
-      for (let i = N; i >= 0; i--) { const x = t0 * i / N; ctx.lineTo(m.X(x), m.Y(Math.sin(x))); }
-      ctx.closePath(); ctx.fillStyle = p.alert + "33"; ctx.fill(); ctx.restore();
-
-      line(ctx, m, x => x, p.small, 2.5);           // y = theta
-      line(ctx, m, x => Math.sin(x), p.exact, 2.5); // y = sin theta
-
-      // markers at t0
-      const yA = m.Y(t0), yS = m.Y(Math.sin(t0)), xM = m.X(t0);
-      ctx.strokeStyle = p.alert; ctx.lineWidth = 2; ctx.setLineDash([4, 4]);
-      ctx.beginPath(); ctx.moveTo(xM, yA); ctx.lineTo(xM, yS); ctx.stroke(); ctx.setLineDash([]);
-      dot(ctx, xM, yA, 4.5, p.small); dot(ctx, xM, yS, 4.5, p.exact);
-
-      const err = (t0 - Math.sin(t0)) / Math.sin(t0) * 100;
-      readout.querySelector('[data-r="rad"]').textContent = t0.toFixed(3);
-      readout.querySelector('[data-r="sin"]').textContent = Math.sin(t0).toFixed(3);
-      const ev = readout.querySelector('[data-r="err"]');
-      ev.textContent = fmtPct(err);
-      ev.style.color = err > 5 ? p.alert : err > 1 ? p.small : p.millet;
-      lab.querySelector("b").textContent = (+sl.value).toFixed(1) + "°";
-    }
-    const r = responsive(body, canvas, 0.62, draw);
-    sl.addEventListener("input", r.relayout);
-  }
-
   /* ========================================================= 2. animated pendulum */
   function vizPendulum(mount) {
     const body = card(mount,
@@ -356,78 +282,6 @@
     bPlay.addEventListener("click", () => { userPaused = !running ? false : true; });
     reset();
   }
-
-  /* ======================================================= 3. period vs amplitude */
-  function vizPeriod(mount) {
-    const body = card(mount,
-      "The payoff: how the period grows with amplitude",
-      "The textbook says the period never changes with amplitude (flat orange line). It does. Drag the cursor to compare the flat approximation, Millet's correction, and the exact elliptic-integral period.");
-    body.appendChild(el("div", "saviz__legend",
-      '<span class="l-small">small-angle (constant)</span>' +
-      '<span class="l-millet">Millet correction</span>' +
-      '<span class="l-exact">exact</span>'));
-    const wrap = el("div", "saviz__canvas-wrap");
-    const canvas = el("canvas"); wrap.appendChild(canvas); body.appendChild(wrap);
-
-    const controls = el("div", "saviz__controls");
-    const c1 = el("div", "saviz__control");
-    const lab = el("label", null, '<span>Amplitude &theta;&#8320;</span><b></b>');
-    const sl = slider(1, 179, 1, 90);
-    c1.appendChild(lab); c1.appendChild(sl); controls.appendChild(c1);
-    body.appendChild(controls);
-
-    const readout = el("div", "saviz__readout"); body.appendChild(readout);
-    readout.innerHTML =
-      '<div class="saviz__stat"><span class="k">exact T / T&#8320;</span><span class="v" data-r="ex"></span></div>' +
-      '<div class="saviz__stat"><span class="k">small-angle error</span><span class="v" data-r="es"></span></div>' +
-      '<div class="saviz__stat"><span class="k">Millet error</span><span class="v" data-r="em"></span></div>';
-
-    function draw(ctx, w, h) {
-      const p = palette(mount);
-      ctx.clearRect(0, 0, w, h);
-      const xmax = 180, ymax = 2.6;
-      const m = mapper(48, 14, w - 64, h - 40, 0, xmax, 1, ymax);
-
-      ctx.strokeStyle = p.sep; ctx.lineWidth = 1; ctx.beginPath();
-      for (let d = 0; d <= 180; d += 30) {
-        const x = m.X(d); ctx.moveTo(x, m.py); ctx.lineTo(x, m.py + m.ph);
-        label(ctx, d + "°", x, m.py + m.ph + 15, p.dim, "11px sans-serif", "center");
-      }
-      for (let v = 1; v <= 2.5; v += 0.5) {
-        const y = m.Y(v); ctx.moveTo(m.px, y); ctx.lineTo(m.px + m.pw, y);
-        label(ctx, v.toFixed(1), m.px - 7, y, p.dim, "11px sans-serif", "right", "middle");
-      }
-      ctx.stroke();
-      label(ctx, "T / T₀", m.px - 7, m.py - 2, p.dim, "11px sans-serif", "right", "bottom");
-
-      line(ctx, m, () => 1, p.small, 2.5);
-      line(ctx, m, d => Tmillet(d * DEG), p.millet, 2.5);
-      line(ctx, m, d => Texact(d * DEG), p.exact, 2.5);
-
-      // reference dots from the paper (30, 90 deg)
-      [30, 90].forEach(d => dot(ctx, m.X(d), m.Y(Texact(d * DEG)), 3, p.exact));
-
-      // cursor
-      const d0 = +sl.value;
-      const xC = m.X(d0);
-      ctx.strokeStyle = p.dim; ctx.lineWidth = 1; ctx.setLineDash([4, 4]);
-      ctx.beginPath(); ctx.moveTo(xC, m.py); ctx.lineTo(xC, m.py + m.ph); ctx.stroke(); ctx.setLineDash([]);
-      const ex = Texact(d0 * DEG), mi = Tmillet(d0 * DEG);
-      dot(ctx, xC, m.Y(1), 5, p.small);
-      dot(ctx, xC, m.Y(Math.min(ymax, mi)), 5, p.millet);
-      dot(ctx, xC, m.Y(Math.min(ymax, ex)), 5, p.exact);
-
-      readout.querySelector('[data-r="ex"]').textContent = ex.toFixed(4);
-      const es = readout.querySelector('[data-r="es"]');
-      es.textContent = fmtPct(Math.abs(1 - ex) / ex * 100); es.style.color = p.small;
-      const em = readout.querySelector('[data-r="em"]');
-      em.textContent = fmtPct(Math.abs(mi - ex) / ex * 100); em.style.color = p.millet;
-      lab.querySelector("b").textContent = d0 + "°";
-    }
-    const r = responsive(body, canvas, 0.6, draw);
-    sl.addEventListener("input", r.relayout);
-  }
-
   /* ===================================================== 4. nonlinear potentials */
   function vizPotential(mount) {
     const SYS = {
@@ -528,7 +382,7 @@
   }
 
   /* -------------------------------------------------------------------- bootstrap */
-  const REG = { approx: vizApprox, pendulum: vizPendulum, period: vizPeriod, potential: vizPotential };
+  const REG = { pendulum: vizPendulum, potential: vizPotential };
   function boot() {
     document.querySelectorAll("[data-viz]").forEach(node => {
       const fn = REG[node.getAttribute("data-viz")];


### PR DESCRIPTION
## TL;DR

Draft post: a 2005 Grove City College classical-mechanics final report on the shortcomings of the small-angle approximation for oscillating systems. Covers the simple pendulum, Millet's large-angle correction, the exact elliptic-integral period, and five of Mohazzabi's intrinsically nonlinear oscillators (tethered mass, two charged rings, a tunnel through a sphere, a bouncing ball, a bead on a wire).

Equations render via KaTeX (`math: true`). Dated to the paper, 2005-12-13.

## Notes

- Ships as `draft: true`; flip the flag to publish.
- Single file: `content/post/small-angle-approximation.md`.
